### PR TITLE
fix: handle more alias names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,14 @@ const ES_VERSIONS_MAP: Record<string, number[]> = {
 	samsung: [5, 6.2, 6.2, 8.2],
 };
 
+const aliases: Record<string, string> = {
+	ios_saf: 'safari',
+	and_chr: 'chrome',
+	and_ff: 'firefox',
+};
+
 const renameBrowser = (name: string) => {
-	return name === 'ios_saf' ? 'safari' : name;
+	return aliases[name] || name;
 };
 
 export function browserslistToESVersion(browsers: string[]): ESVersion {

--- a/test/index.js
+++ b/test/index.js
@@ -59,4 +59,9 @@ test('should get ECMA version correctly', () => {
 	);
 	assert.strictEqual(browserslistToESVersion(['ie 11', 'baidu 7.12']), 5);
 	assert.strictEqual(browserslistToESVersion(['ios_saf 11']), 2017);
+
+	// https://github.com/browserslist/browserslist/issues/682
+	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2018);
+	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2018);
+	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2018);
 });


### PR DESCRIPTION
Handle more alias names like `and_chr` or `and_ff`.