### PR TITLE
feat: support for es2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm add browserslist-to-es-version -D
 Example:
 
 ```ts
-import { browserslistToESVersion } from 'browserslist-to-es-version';
+import { browserslistToESVersion } from "browserslist-to-es-version";
 
 const esVersion = browserslistToESVersion([
   "chrome >= 87",
@@ -35,11 +35,20 @@ console.log(esVersion); // 2017
 ## Type
 
 ```ts
-// Only supports ES5 ~ ES2018
-type ESVersion = 5 | 2015 | 2016 | 2017 | 2018;
+// Only supports ES5 ~ ES2019
+type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019;
 
 function browserslistToESVersion(browsers: string[]): ESVersion;
 ```
+
+## Data source
+
+- https://caniuse.com/?search=es2019
+- https://caniuse.com/?search=es2018
+- https://caniuse.com/?search=es2017
+- https://caniuse.com/?search=es2016
+- https://caniuse.com/?search=es2015
+- https://caniuse.com/?search=es5
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 import browserslist from 'browserslist';
 
-export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018;
+export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019;
 
-// The minimal version for [es2015, es2016, es2017, es2018]
+// The minimal version for [es2015, es2016, es2017, es2018, es2019]
 const ES_VERSIONS_MAP: Record<string, number[]> = {
-	chrome: [51, 52, 57, 64],
-	edge: [15, 15, 15, 79],
-	safari: [10, 10.3, 11, 16.4],
-	firefox: [54, 54, 54, 78],
-	opera: [38, 39, 44, 51],
-	samsung: [5, 6.2, 6.2, 8.2],
+	chrome: [51, 52, 57, 64, 73],
+	edge: [15, 15, 15, 79, 79],
+	safari: [10, 10.3, 11, 16.4, 17],
+	firefox: [54, 54, 54, 78, 64],
+	opera: [38, 39, 44, 51, 60],
+	samsung: [5, 6.2, 6.2, 8.2, 11.1],
 };
 
 const aliases: Record<string, string> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const ES_VERSIONS_MAP: Record<string, number[]> = {
 	chrome: [51, 52, 57, 64, 73],
 	edge: [15, 15, 15, 79, 79],
 	safari: [10, 10.3, 11, 16.4, 17],
-	firefox: [54, 54, 54, 78, 64],
+	firefox: [54, 54, 54, 78, 78],
 	opera: [38, 39, 44, 51, 60],
 	samsung: [5, 6.2, 6.2, 8.2, 11.1],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 		ignoreUnknownVersions: true,
 	});
 
-	let esVersion: ESVersion = 2018;
+	let esVersion: ESVersion = 2019;
 
 	for (const item of projectBrowsers) {
 		const pairs = item.split(' ');
@@ -65,6 +65,8 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 			esVersion = Math.min(2016, esVersion) as ESVersion;
 		} else if (version < versions[3]) {
 			esVersion = Math.min(2017, esVersion) as ESVersion;
+		} else if (version < versions[4]) {
+			esVersion = Math.min(2018, esVersion) as ESVersion;
 		}
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,9 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['Edge >= 12']), 5);
 	assert.strictEqual(browserslistToESVersion(['Edge >= 15']), 2017);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 53']), 2016);
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 63']), 2017);
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 67']), 2018);
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 73']), 2019);
 	assert.strictEqual(browserslistToESVersion(['ie >= 11', 'Chrome >= 53']), 5);
 	assert.strictEqual(
 		browserslistToESVersion(['Edge >= 15', 'Chrome >= 53']),
@@ -39,7 +42,7 @@ test('should get ECMA version correctly', () => {
 			'last 1 firefox version',
 			'last 1 safari version',
 		]),
-		2018,
+		2019,
 	);
 	assert.strictEqual(
 		browserslistToESVersion([
@@ -60,7 +63,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['ios_saf 11']), 2017);
 
 	// https://github.com/browserslist/browserslist/issues/682
-	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2018);
-	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2018);
-	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2018);
+	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2019);
+	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2019);
+	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2019);
 });


### PR DESCRIPTION
Add support for ES2019, including changes to the type definitions, documentation, and internal mappings for browser versions.