### PR TITLE
feat: support for es2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ console.log(esVersion); // 2017
 ## Type
 
 ```ts
-// Only supports ES5 ~ ES2019
-type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019;
+// Only supports ES5 ~ ES2020
+type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
 
 function browserslistToESVersion(browsers: string[]): ESVersion;
 ```
 
 ## Data source
 
+- https://caniuse.com/?search=es2020
 - https://caniuse.com/?search=es2019
 - https://caniuse.com/?search=es2018
 - https://caniuse.com/?search=es2017

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 import browserslist from 'browserslist';
 
-export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019;
+export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
 
-// The minimal version for [es2015, es2016, es2017, es2018, es2019]
+// The minimal version for [es2015, es2016, es2017, es2018, es2019, es2020]
 const ES_VERSIONS_MAP: Record<string, number[]> = {
-	chrome: [51, 52, 57, 64, 73],
-	edge: [15, 15, 15, 79, 79],
-	safari: [10, 10.3, 11, 16.4, 17],
-	firefox: [54, 54, 54, 78, 78],
-	opera: [38, 39, 44, 51, 60],
-	samsung: [5, 6.2, 6.2, 8.2, 11.1],
+	chrome: [51, 52, 57, 64, 73, 80],
+	edge: [15, 15, 15, 79, 79, 80],
+	safari: [10, 10.3, 11, 16.4, 17, 17],
+	firefox: [54, 54, 54, 78, 78, 80],
+	opera: [38, 39, 44, 51, 60, 67],
+	samsung: [5, 6.2, 6.2, 8.2, 11.1, 13],
 };
 
 const aliases: Record<string, string> = {
@@ -27,7 +27,7 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 		ignoreUnknownVersions: true,
 	});
 
-	let esVersion: ESVersion = 2019;
+	let esVersion: ESVersion = 2020;
 
 	for (const item of projectBrowsers) {
 		const pairs = item.split(' ');
@@ -67,6 +67,8 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 			esVersion = Math.min(2017, esVersion) as ESVersion;
 		} else if (version < versions[4]) {
 			esVersion = Math.min(2018, esVersion) as ESVersion;
+		} else if (version < versions[5]) {
+			esVersion = Math.min(2019, esVersion) as ESVersion;
 		}
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,16 +2,56 @@ import { assert, test } from '@rstest/core';
 import { browserslistToESVersion } from '../dist/index.js';
 
 test('should get ECMA version correctly', () => {
-	assert.strictEqual(browserslistToESVersion(['iOS 8']), 5);
+	// IE
 	assert.strictEqual(browserslistToESVersion(['ie >= 11']), 5);
-	assert.strictEqual(browserslistToESVersion(['android >= 4.4']), 5);
-	assert.strictEqual(browserslistToESVersion(['Chrome >= 33']), 5);
+
+	// Edge
 	assert.strictEqual(browserslistToESVersion(['Edge >= 12']), 5);
 	assert.strictEqual(browserslistToESVersion(['Edge >= 15']), 2017);
+
+	// Firefox
+	assert.strictEqual(browserslistToESVersion(['firefox >= 50']), 5);
+	assert.strictEqual(browserslistToESVersion(['firefox >= 54']), 2017);
+	assert.strictEqual(browserslistToESVersion(['firefox >= 78']), 2019);
+	assert.strictEqual(browserslistToESVersion(['firefox >= 80']), 2020);
+
+	// Chrome
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 33']), 5);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 53']), 2016);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 63']), 2017);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 67']), 2018);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 73']), 2019);
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 80']), 2020);
+
+	// Opera
+	assert.strictEqual(browserslistToESVersion(['opera >= 30']), 5);
+	assert.strictEqual(browserslistToESVersion(['opera >= 38']), 2015);
+	assert.strictEqual(browserslistToESVersion(['opera >= 39']), 2016);
+	assert.strictEqual(browserslistToESVersion(['opera >= 44']), 2017);
+	assert.strictEqual(browserslistToESVersion(['opera >= 51']), 2018);
+	assert.strictEqual(browserslistToESVersion(['opera >= 60']), 2019);
+	assert.strictEqual(browserslistToESVersion(['opera >= 67']), 2020);
+
+	// Samsung
+	assert.strictEqual(browserslistToESVersion(['samsung >= 4']), 5);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 5']), 2015);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 6.2']), 2017);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 8.2']), 2018);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 11.1']), 2019);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 13']), 2020);
+
+	// Safari
+	assert.strictEqual(browserslistToESVersion(['safari >= 10']), 2015);
+	assert.strictEqual(browserslistToESVersion(['safari >= 10.3']), 2017);
+	assert.strictEqual(browserslistToESVersion(['safari >= 11']), 2017);
+
+	// iOS
+	assert.strictEqual(browserslistToESVersion(['iOS 8']), 5);
+
+	// Android
+	assert.strictEqual(browserslistToESVersion(['android >= 4.4']), 5);
+
+	// Mixed
 	assert.strictEqual(browserslistToESVersion(['ie >= 11', 'Chrome >= 53']), 5);
 	assert.strictEqual(
 		browserslistToESVersion(['Edge >= 15', 'Chrome >= 53']),
@@ -42,7 +82,7 @@ test('should get ECMA version correctly', () => {
 			'last 1 firefox version',
 			'last 1 safari version',
 		]),
-		2019,
+		2020,
 	);
 	assert.strictEqual(
 		browserslistToESVersion([
@@ -54,6 +94,8 @@ test('should get ECMA version correctly', () => {
 		]),
 		2015,
 	);
+
+	// Other
 	assert.strictEqual(browserslistToESVersion(['fully supports es6']), 2015);
 	assert.strictEqual(
 		browserslistToESVersion(['fully supports es6-module']),
@@ -63,7 +105,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['ios_saf 11']), 2017);
 
 	// https://github.com/browserslist/browserslist/issues/682
-	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2019);
-	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2019);
-	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2019);
+	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2020);
+	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2020);
+	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2020);
 });


### PR DESCRIPTION
Add support for `es2020`.

https://caniuse.com/?feats=mdn-javascript_operators_optional_chaining,mdn-javascript_operators_nullish_coalescing,mdn-javascript_builtins_globalthis,es6-module-dynamic-import,bigint,mdn-javascript_builtins_promise_allsettled,mdn-javascript_builtins_string_matchall,mdn-javascript_statements_export_namespace,mdn-javascript_operators_import_meta