### PR TITLE
feat: add support for es2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ console.log(esVersion); // 2017
 ## Type
 
 ```ts
-// Only supports ES5 ~ ES2020
-type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
+// Only supports ES5 ~ ES2021
+type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021;
 
 function browserslistToESVersion(browsers: string[]): ESVersion;
 ```
 
 ## Data source
 
+- https://caniuse.com/?search=es2021
 - https://caniuse.com/?search=es2020
 - https://caniuse.com/?search=es2019
 - https://caniuse.com/?search=es2018

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 import browserslist from 'browserslist';
 
-export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
+export type ESVersion = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021;
 
-// The minimal version for [es2015, es2016, es2017, es2018, es2019, es2020]
+// The minimal version for [es2015, es2016, es2017, es2018, es2019, es2020, es2021]
 const ES_VERSIONS_MAP: Record<string, number[]> = {
-	chrome: [51, 52, 57, 64, 73, 80],
-	edge: [15, 15, 15, 79, 79, 80],
-	safari: [10, 10.3, 11, 16.4, 17, 17],
-	firefox: [54, 54, 54, 78, 78, 80],
-	opera: [38, 39, 44, 51, 60, 67],
-	samsung: [5, 6.2, 6.2, 8.2, 11.1, 13],
+	chrome: [51, 52, 57, 64, 73, 80, 85],
+	edge: [15, 15, 15, 79, 79, 80, 85],
+	safari: [10, 10.3, 11, 16.4, 17, 17, 17],
+	firefox: [54, 54, 54, 78, 78, 80, 80],
+	opera: [38, 39, 44, 51, 60, 67, 71],
+	samsung: [5, 6.2, 6.2, 8.2, 11.1, 13, 14],
 };
 
 const aliases: Record<string, string> = {
@@ -27,7 +27,7 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 		ignoreUnknownVersions: true,
 	});
 
-	let esVersion: ESVersion = 2020;
+	let esVersion: ESVersion = 2021;
 
 	for (const item of projectBrowsers) {
 		const pairs = item.split(' ');
@@ -69,6 +69,8 @@ export function browserslistToESVersion(browsers: string[]): ESVersion {
 			esVersion = Math.min(2018, esVersion) as ESVersion;
 		} else if (version < versions[5]) {
 			esVersion = Math.min(2019, esVersion) as ESVersion;
+		} else if (version < versions[6]) {
+			esVersion = Math.min(2020, esVersion) as ESVersion;
 		}
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,12 +8,15 @@ test('should get ECMA version correctly', () => {
 	// Edge
 	assert.strictEqual(browserslistToESVersion(['Edge >= 12']), 5);
 	assert.strictEqual(browserslistToESVersion(['Edge >= 15']), 2017);
+	assert.strictEqual(browserslistToESVersion(['Edge >= 79']), 2019);
+	assert.strictEqual(browserslistToESVersion(['Edge >= 80']), 2020);
+	assert.strictEqual(browserslistToESVersion(['Edge >= 85']), 2021);
 
 	// Firefox
 	assert.strictEqual(browserslistToESVersion(['firefox >= 50']), 5);
 	assert.strictEqual(browserslistToESVersion(['firefox >= 54']), 2017);
 	assert.strictEqual(browserslistToESVersion(['firefox >= 78']), 2019);
-	assert.strictEqual(browserslistToESVersion(['firefox >= 80']), 2020);
+	assert.strictEqual(browserslistToESVersion(['firefox >= 85']), 2021);
 
 	// Chrome
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 33']), 5);
@@ -22,6 +25,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 67']), 2018);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 73']), 2019);
 	assert.strictEqual(browserslistToESVersion(['Chrome >= 80']), 2020);
+	assert.strictEqual(browserslistToESVersion(['Chrome >= 85']), 2021);
 
 	// Opera
 	assert.strictEqual(browserslistToESVersion(['opera >= 30']), 5);
@@ -31,6 +35,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['opera >= 51']), 2018);
 	assert.strictEqual(browserslistToESVersion(['opera >= 60']), 2019);
 	assert.strictEqual(browserslistToESVersion(['opera >= 67']), 2020);
+	assert.strictEqual(browserslistToESVersion(['opera >= 71']), 2021);
 
 	// Samsung
 	assert.strictEqual(browserslistToESVersion(['samsung >= 4']), 5);
@@ -39,6 +44,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['samsung >= 8.2']), 2018);
 	assert.strictEqual(browserslistToESVersion(['samsung >= 11.1']), 2019);
 	assert.strictEqual(browserslistToESVersion(['samsung >= 13']), 2020);
+	assert.strictEqual(browserslistToESVersion(['samsung >= 14']), 2021);
 
 	// Safari
 	assert.strictEqual(browserslistToESVersion(['safari >= 10']), 2015);
@@ -82,7 +88,7 @@ test('should get ECMA version correctly', () => {
 			'last 1 firefox version',
 			'last 1 safari version',
 		]),
-		2020,
+		2021,
 	);
 	assert.strictEqual(
 		browserslistToESVersion([
@@ -105,7 +111,7 @@ test('should get ECMA version correctly', () => {
 	assert.strictEqual(browserslistToESVersion(['ios_saf 11']), 2017);
 
 	// https://github.com/browserslist/browserslist/issues/682
-	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2020);
-	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2020);
-	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2020);
+	assert.strictEqual(browserslistToESVersion(['and_ff >= 78']), 2021);
+	assert.strictEqual(browserslistToESVersion(['and_chr >= 53']), 2021);
+	assert.strictEqual(browserslistToESVersion(['ChromeAndroid >= 53']), 2021);
 });


### PR DESCRIPTION
Add support for `es2021`.

https://caniuse.com/?search=es2021